### PR TITLE
Update glibc_version_header_gen.py

### DIFF
--- a/glibc_version_header_gen.py
+++ b/glibc_version_header_gen.py
@@ -38,7 +38,7 @@ def extract_versions_from_installed_folder(folder, version, arch):
         # See https://web.archive.org/web/20170124195801/https://www.akkadia.org/drepper/symbol-versioning section Static Linker
         command = "readelf -Ws '" + f + "' | grep \" [^ ]*@@GLIBC_[0-9.]*$\" -o"
         file_data = [x.decode("utf-8").strip() for x in
-                     subprocess.check_output(['/bin/bash', '-c', 'set -o pipefail; ' + command]).split()]
+                     subprocess.check_output(['/bin/bash', '-c', 'set -o pipefail; ', command]).split()]
 
         library_name = f.split("/")[-1]
         if Version(2, 17) <= version <= Version(2, 27):


### PR DESCRIPTION
Changed a + string append to a , string append. This seems to better match the expected behavior, where each argument is its own string in a list. This fixes a bug when running the bash command. `subprocess.CalledProcessError: Command '['/bin/bash', '-c', 'set -o pipefail; readelf -Ws \'/home/bgalacci/repos/glibc_version_header/builds/glibc-2.26/install/usr/local/lib/libanl-2.26.so\' | grep " [^ ]*@@GLIBC_[0-9.]*$ " -o']' returned non-zero exit status 1.`, despite the .so file existing in that location.

Before:
'['/bin/bash', '-c', 'set -o **pipefail; readelf** -Ws \'/home/bgalacci/repos/glibc_version_header/builds/glibc-2.26/install/usr/local/lib/libanl-2.26.so\' | grep " [^ ]\*@@GLIBC_[0-9.]\*$ " -o']' 
After:
'['/bin/bash', '-c', 'set -o **pipefail; ', 'readelf** -Ws \'/home/bgalacci/repos/glibc_version_header/builds/glibc-2.26/install/usr/local/lib/libanl-2.26.so\' | grep " [^ ]\*@@GLIBC_[0-9.]\*$ " -o']'